### PR TITLE
make the project build if there are spaces in the path

### DIFF
--- a/CMU462/deps/glfw/docs/CMakeLists.txt
+++ b/CMU462/deps/glfw/docs/CMakeLists.txt
@@ -1,20 +1,20 @@
 
 set(glfw_DOCS_SOURCES
-    "${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h"
-    "${GLFW_SOURCE_DIR}/include/GLFW/glfw3native.h"
-    "${GLFW_SOURCE_DIR}/docs/main.dox"
-    "${GLFW_SOURCE_DIR}/docs/news.dox"
-    "${GLFW_SOURCE_DIR}/docs/moving.dox"
-    "${GLFW_SOURCE_DIR}/docs/quick.dox"
-    "${GLFW_SOURCE_DIR}/docs/compile.dox"
-    "${GLFW_SOURCE_DIR}/docs/build.dox"
-    "${GLFW_SOURCE_DIR}/docs/intro.dox"
-    "${GLFW_SOURCE_DIR}/docs/context.dox"
-    "${GLFW_SOURCE_DIR}/docs/monitor.dox"
-    "${GLFW_SOURCE_DIR}/docs/window.dox"
-    "${GLFW_SOURCE_DIR}/docs/input.dox"
-    "${GLFW_SOURCE_DIR}/docs/vulkan.dox"
-    "${GLFW_SOURCE_DIR}/docs/compat.dox")
+    "\"${GLFW_SOURCE_DIR}/include/GLFW/glfw3.h\""
+    "\"${GLFW_SOURCE_DIR}/include/GLFW/glfw3native.h\""
+    "\"${GLFW_SOURCE_DIR}/docs/main.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/news.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/moving.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/quick.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/compile.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/build.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/intro.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/context.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/monitor.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/window.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/input.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/vulkan.dox\""
+    "\"${GLFW_SOURCE_DIR}/docs/compat.dox\"")
 
 if (GLFW_DOCUMENT_INTERNALS)
     list(APPEND glfw_DOCS_SOURCES "${GLFW_SOURCE_DIR}/src/internal.h")

--- a/CMU462/deps/glfw/docs/Doxyfile.in
+++ b/CMU462/deps/glfw/docs/Doxyfile.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @GLFW_BINARY_DIR@/docs
+OUTPUT_DIRECTORY       = "@GLFW_BINARY_DIR@/docs"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -720,7 +720,7 @@ EXCLUDE_SYMBOLS        = APIENTRY GLFWAPI
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = @GLFW_SOURCE_DIR@/examples
+EXAMPLE_PATH           = "@GLFW_SOURCE_DIR@/examples"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp
@@ -896,13 +896,13 @@ HTML_FILE_EXTENSION    = .html
 # have to redo this when upgrading to a newer version of doxygen or when
 # changing the value of configuration settings such as GENERATE_TREEVIEW!
 
-HTML_HEADER            = @GLFW_SOURCE_DIR@/docs/header.html
+HTML_HEADER            = "@GLFW_SOURCE_DIR@/docs/header.html"
 
 # The HTML_FOOTER tag can be used to specify a personal HTML footer for
 # each generated HTML page. If it is left blank doxygen will generate a
 # standard footer.
 
-HTML_FOOTER            = @GLFW_SOURCE_DIR@/docs/footer.html
+HTML_FOOTER            = "@GLFW_SOURCE_DIR@/docs/footer.html"
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading
 # style sheet that is used by each HTML page. It can be used to
@@ -921,7 +921,7 @@ HTML_STYLESHEET        =
 # robust against future updates. Doxygen will copy the style sheet file to
 # the output directory.
 
-HTML_EXTRA_STYLESHEET  = @GLFW_SOURCE_DIR@/docs/extra.css
+HTML_EXTRA_STYLESHEET  = "@GLFW_SOURCE_DIR@/docs/extra.css"
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note
@@ -930,7 +930,7 @@ HTML_EXTRA_STYLESHEET  = @GLFW_SOURCE_DIR@/docs/extra.css
 # files. In the HTML_STYLESHEET file, use the file name only. Also note that
 # the files will be copied as-is; there are no commands or markers available.
 
-HTML_EXTRA_FILES       = @GLFW_SOURCE_DIR@/docs/spaces.svg
+HTML_EXTRA_FILES       = "@GLFW_SOURCE_DIR@/docs/spaces.svg"
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output.
 # Doxygen will adjust the colors in the style sheet and background images


### PR DESCRIPTION
Currently, if you have spaces in the path where this repository is cloned, make fails because it cannot find certain files. These changes fix this issue by adding quotes in the relevant places so that the path is treated as a single string, including spaces.