### PR TITLE
Typo fix: File does not exist

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int loadPath( DrawSVG* drawsvg, const char* path) {
 
   // file exist?
   if(stat(path, &st) < 0 ) {
-    msg("File does not exit: " << path);
+    msg("File does not exist: " << path);
     return -1;
   }
 


### PR DESCRIPTION
The error message should be "File does not exist: " instead of "File does not exit: ".